### PR TITLE
fix(js): prevent brutal-select dropdown from closing itself during to…

### DIFF
--- a/portal/static/js/brutal-select.js
+++ b/portal/static/js/brutal-select.js
@@ -88,7 +88,7 @@ function upgradeSelects() {
       if (select.disabled) return;
       isOpen = !isOpen;
       if (isOpen) {
-        closeAll();
+        closeAll(wrapper);
         optionsDiv.classList.remove(
           "opacity-0",
           "invisible",
@@ -127,10 +127,14 @@ function upgradeSelects() {
   });
 }
 
-function closeAll() {
+function closeAll(except = null) {
   document
     .querySelectorAll(".custom-select-wrapper")
-    .forEach((w) => w.customSelectClose && w.customSelectClose());
+    .forEach((w) => {
+      if (w !== except && w.customSelectClose) {
+        w.customSelectClose();
+      }
+    });
 }
 
 document.addEventListener("click", closeAll);


### PR DESCRIPTION
## Summary

This PR fixes the brutal-select dropdown closing itself while toggling.

### Root cause

`toggle()` called `closeAll()`, which also closed the dropdown currently being opened. This caused the dropdown to immediately close/reopen and resulted in inconsistent `isOpen` state.

### Fix

- Pass the current wrapper to `closeAll()`
- Skip the active dropdown while closing other dropdowns
- Preserve the existing outside-click behavior

Fixes #452

## Summary by Sourcery

Bug Fixes:
- Prevent the brutal-select dropdown from closing itself when toggled open by excluding the active dropdown from bulk close operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dropdown behavior when opening a menu.
  - Opening one dropdown now closes other open dropdowns without immediately closing the selected menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->