### PR TITLE
fix(admin): let an event with a relay booth be deleted

### DIFF
--- a/portal/database.py
+++ b/portal/database.py
@@ -175,11 +175,11 @@ async def delete_event(session: AsyncSession, event_id: int) -> bool:
     if ev is None:
         return False
     # Break the circular FK cycle: rooms.relay_booth_id → booths.id ↔ booths.room_id → rooms.id
-    # null out the back-references so the cascade can order the deletes
+    # assign the relationship, not the column, so an already-loaded relay_booth is
+    # cleared too and the unit of work no longer sees the Room ↔ DBBooth dependency
     result = await session.execute(select(Room).where(Room.event_id == event_id))
     for room in result.scalars().all():
-        room.relay_booth_id = None
-    await session.flush()
+        room.relay_booth = None
     await session.delete(ev)
     await session.flush()
     return True

--- a/portal/database.py
+++ b/portal/database.py
@@ -174,6 +174,12 @@ async def delete_event(session: AsyncSession, event_id: int) -> bool:
     ev = await get_event_by_id(session, event_id)
     if ev is None:
         return False
+    # Break the circular FK cycle: rooms.relay_booth_id → booths.id ↔ booths.room_id → rooms.id
+    # null out the back-references so the cascade can order the deletes
+    result = await session.execute(select(Room).where(Room.event_id == event_id))
+    for room in result.scalars().all():
+        room.relay_booth_id = None
+    await session.flush()
     await session.delete(ev)
     await session.flush()
     return True

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -264,6 +264,29 @@ class TestEventCRUD:
         assert b"testcon" not in resp.content
 
     @pytest.mark.anyio
+    async def test_delete_event_with_a_relay_booth(self, admin_cookie, seed_event):
+        """Relay Settings sets rooms.relay_booth_id; the event must still be deletable."""
+        event, room, booth = seed_event
+        async with _client() as c:
+            resp = await c.post(
+                f"/admin/events/{event.id}/rooms/{room.id}/edit",
+                data={"form_section": "relay", "relay_booth_id": str(booth.id)},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+            assert resp.status_code == 303
+
+            resp = await c.post(
+                f"/admin/events/{event.id}/delete",
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with _client() as c:
+            resp = await c.get("/admin/events/", cookies=admin_cookie)
+        assert b"testcon" not in resp.content
+
+    @pytest.mark.anyio
     async def test_event_not_found(self, admin_cookie):
         async with _client() as c:
             resp = await c.get("/admin/events/99999/", cookies=admin_cookie)

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -276,6 +276,14 @@ class TestEventCRUD:
             )
             assert resp.status_code == 303
 
+        # 303 alone does not prove the relay was stored, and without it stored
+        # this test would delete an ordinary event and miss the FK cycle.
+        from portal.database import get_room_by_id, get_session
+
+        async with get_session() as s:
+            assert (await get_room_by_id(s, room.id)).relay_booth_id == booth.id
+
+        async with _client() as c:
             resp = await c.post(
                 f"/admin/events/{event.id}/delete",
                 cookies=admin_cookie,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -159,23 +159,59 @@ async def test_delete_event(db: AsyncSession):
 @pytest.mark.anyio
 async def test_delete_event_with_a_relay_booth(db: AsyncSession):
     """rooms.relay_booth_id points at a booth that points back at the room."""
+    # A throwaway event with its own rooms first, so the target event's id cannot
+    # coincide with any of its room ids and hide a filter reading the wrong column.
+    other = await create_event(db, slug="ev-offset", display_name="Offset")
+    for i in range(3):
+        await create_room(db, event_id=other.id, display_name=f"Other {i}")
     ev = await create_event(db, slug="ev-relay-del", display_name="Ev")
+    rooms = []
+    for code, name in (("en", "English"), ("es", "Spanish"), ("fr", "French")):
+        room = await create_room(db, event_id=ev.id, display_name=f"Room {code}")
+        booth = await create_booth(
+            db, event_id=ev.id, room_id=room.id, language_code=code, language_name=name
+        )
+        room.relay_booth_id = booth.id
+        db.add(InviteToken(booth_id=booth.id, token=generate_token(), role="interpreter"))
+        rooms.append((room, booth))
+    await db.flush()
+    assert all(room.id != ev.id for room, _ in rooms)
+
+    for room, booth in rooms:
+        assert len(await list_booths_for_room(db, room.id)) == 1
+        assert len(await list_tokens_for_booth(db, booth.id)) == 1
+
+    assert await delete_event(db, ev.id) is True
+    assert await get_event_by_id(db, ev.id) is None
+    for room, booth in rooms:
+        assert await get_room_by_id(db, room.id) is None
+        assert await get_booth_by_id(db, booth.id) is None
+        assert await list_booths_for_room(db, room.id) == []
+        assert await list_tokens_for_booth(db, booth.id) == []
+
+
+@pytest.mark.anyio
+async def test_delete_event_with_a_relay_booth_already_loaded(db: AsyncSession):
+    """Clearing only the column would leave the loaded relationship holding the cycle."""
+    from sqlalchemy import select as sa_select
+    from sqlalchemy.orm import joinedload
+
+    ev = await create_event(db, slug="ev-relay-loaded", display_name="Ev")
     room = await create_room(db, event_id=ev.id, display_name="Room")
     booth = await create_booth(
         db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English"
     )
     room.relay_booth_id = booth.id
-    db.add(InviteToken(booth_id=booth.id, token=generate_token(), role="interpreter"))
     await db.flush()
 
-    assert len(await list_booths_for_room(db, room.id)) == 1
-    assert len(await list_tokens_for_booth(db, booth.id)) == 1
+    loaded = await db.execute(
+        sa_select(Room).where(Room.id == room.id).options(joinedload(Room.relay_booth))
+    )
+    assert loaded.scalars().first().relay_booth is not None
 
     assert await delete_event(db, ev.id) is True
     assert await get_event_by_id(db, ev.id) is None
     assert await get_room_by_id(db, room.id) is None
-    assert await list_booths_for_room(db, room.id) == []
-    assert await list_tokens_for_booth(db, booth.id) == []
 
 
 @pytest.mark.anyio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -168,9 +168,7 @@ async def test_delete_event_with_a_relay_booth(db: AsyncSession):
     rooms = []
     for code, name in (("en", "English"), ("es", "Spanish"), ("fr", "French")):
         room = await create_room(db, event_id=ev.id, display_name=f"Room {code}")
-        booth = await create_booth(
-            db, event_id=ev.id, room_id=room.id, language_code=code, language_name=name
-        )
+        booth = await create_booth(db, event_id=ev.id, room_id=room.id, language_code=code, language_name=name)
         room.relay_booth_id = booth.id
         db.add(InviteToken(booth_id=booth.id, token=generate_token(), role="interpreter"))
         rooms.append((room, booth))
@@ -198,15 +196,11 @@ async def test_delete_event_with_a_relay_booth_already_loaded(db: AsyncSession):
 
     ev = await create_event(db, slug="ev-relay-loaded", display_name="Ev")
     room = await create_room(db, event_id=ev.id, display_name="Room")
-    booth = await create_booth(
-        db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English"
-    )
+    booth = await create_booth(db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English")
     room.relay_booth_id = booth.id
     await db.flush()
 
-    loaded = await db.execute(
-        sa_select(Room).where(Room.id == room.id).options(joinedload(Room.relay_booth))
-    )
+    loaded = await db.execute(sa_select(Room).where(Room.id == room.id).options(joinedload(Room.relay_booth)))
     assert loaded.scalars().first().relay_booth is not None
 
     assert await delete_event(db, ev.id) is True

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -157,6 +157,22 @@ async def test_delete_event(db: AsyncSession):
 
 
 @pytest.mark.anyio
+async def test_delete_event_with_a_relay_booth(db: AsyncSession):
+    """rooms.relay_booth_id points at a booth that points back at the room."""
+    ev = await create_event(db, slug="ev-relay-del", display_name="Ev")
+    room = await create_room(db, event_id=ev.id, display_name="Room")
+    booth = await create_booth(
+        db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English"
+    )
+    room.relay_booth_id = booth.id
+    await db.flush()
+
+    assert await delete_event(db, ev.id) is True
+    assert await get_event_by_id(db, ev.id) is None
+    assert await get_room_by_id(db, room.id) is None
+
+
+@pytest.mark.anyio
 async def test_delete_event_not_found(db: AsyncSession):
     assert await delete_event(db, 99999) is False
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -165,11 +165,17 @@ async def test_delete_event_with_a_relay_booth(db: AsyncSession):
         db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English"
     )
     room.relay_booth_id = booth.id
+    db.add(InviteToken(booth_id=booth.id, token=generate_token(), role="interpreter"))
     await db.flush()
+
+    assert len(await list_booths_for_room(db, room.id)) == 1
+    assert len(await list_tokens_for_booth(db, booth.id)) == 1
 
     assert await delete_event(db, ev.id) is True
     assert await get_event_by_id(db, ev.id) is None
     assert await get_room_by_id(db, room.id) is None
+    assert await list_booths_for_room(db, room.id) == []
+    assert await list_tokens_for_booth(db, booth.id) == []
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Description

An event whose room had a Relay Booth set could not be deleted. The admin panel
returned 500 and the event, its rooms and its booths all survived, with no way to
delete it from the panel at all.

## Related Issue

Closes #456

## Changes Made

- `delete_event` clears `Room.relay_booth` for the event's rooms before deleting, then
  lets the existing cascade run. This is the cycle break `delete_room` already performs
  at `database.py:245`, except it assigns the relationship rather than the column:
  setting `relay_booth_id` alone leaves an already-loaded `relay_booth` in place and the
  unit of work still raises. Nothing eager loads it today, so the column version worked,
  but one `joinedload` on the delete path would bring the 500 back.
- Rooms are selected with an uncapped query, not `list_rooms_for_event`, which caps at
  100. With the helper, rooms 101+ would keep their relay pointer and still raise.
  Checked against 150 relaying rooms.
- Tests at both levels: `delete_event` directly, and `POST /admin/events/{id}/delete`
  after setting the Relay Booth through the room form, which is how an admin hits it.
  
  
<img width="2543" height="889" alt="image" src="https://github.com/user-attachments/assets/1e0d2547-6401-4936-9c1a-b1d2ec1a9f56" />


## Testing

```
POST /admin/events/1/delete  ->  303        (was 500)
uv run pytest tests/ -q          555 passed
uv run ruff check .              All checks passed!
```

Mutation-checked rather than assumed. Each of these fails at least one test, where the
first three previously passed all of them:

```
revert the fix entirely                     -> 2 fail
null only the first room                    -> 1 fail   (fixture has 3 relaying rooms)
filter Room.id instead of Room.event_id     -> 1 fail   (ids offset so they cannot coincide)
set the column instead of the relationship  -> 1 fail   (a case eager loads it first)
```

The admin test asserts the stored `relay_booth_id` before deleting, since a 303 alone
would also come back if the relay had not persisted, and the test would then delete an
ordinary event without exercising the cycle. Walked through in Chromium too: Delete
opens the panel's confirm modal, Confirm lands on the events list with no 500.

- [x] Tested locally
- [x] Existing tests pass
- [x] Added/updated tests (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] My changes do not introduce new warnings or errors

## Additional Notes

Three pre-existing things found while testing, all behaving identically on `main`, none
folded in. Filed separately:

1. #458 - deleting an event leaves rows in seven tables pointing at deleted ids, because
   `PRAGMA foreign_keys` is 0 so the `ondelete="CASCADE"` declarations never fire.
   Verified as a row-for-row identical leak before and after this change, so this PR does
   not widen it, though events that previously could not be deleted at all can now be
   deleted and leak the same way.
2. #459 - deleting a booth that is a room's relay source leaves `relay_booth_id` dangling,
   and SQLite reuses the rowid, so the next booth created silently inherits the relay slot.
   An interpreter then gets another room's stream as their relay source.
3. #460 - `admin_delete_event` drops `delete_event`'s return value, so deleting an event id
   that does not exist redirects as success, and it has no error handling.

## Summary by Sourcery

Fix event deletion for rooms that reference relay booths by clearing those relationships before the event cascade runs.

Bug Fixes:
- Allow events with relay booths configured on their rooms to be deleted successfully.

Tests:
- Add database and admin-panel coverage for deleting events with relay booths, including already-loaded relationships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Fixed event deletion for events containing rooms linked to relay booths.
- Events can now be deleted successfully even when relay booth details are already loaded.
- Related rooms, booths, and invitation tokens are removed as expected during event deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->