### PR TITLE
fix: return 404 on deleting nonexistent event and handle db errors

### DIFF
--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -93,6 +93,7 @@ from portal.websockets.manager import broadcast_transcription
 
 _BASE_DIR = Path(__file__).resolve().parent.parent
 
+logger = logging.getLogger(__name__)
 templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
 
 
@@ -659,8 +660,16 @@ async def admin_event_api_settings_post(
 
 @router.post("/admin/events/{event_id}/delete", dependencies=[Depends(require_admin)])
 async def admin_delete_event(request: Request, event_id: int):
-    async with get_session() as session:
-        await delete_event(session, event_id)
+    try:
+        async with get_session() as session:
+            deleted = await delete_event(session, event_id)
+            if not deleted:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found.")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to delete event {event_id}: {e}")
+        return safe_redirect(url="/admin/events/?error=delete_failed", status_code=status.HTTP_303_SEE_OTHER)
     return safe_redirect(url="/admin/events/", status_code=status.HTTP_303_SEE_OTHER)
 
 
@@ -834,7 +843,6 @@ async def get_translation_models():
     return TRANSLATION_MODELS
 
 
-logger = logging.getLogger(__name__)
 MAX_AUDIO_DELAY_MS = 10_000
 
 

--- a/portal/templates/admin/event_list.html
+++ b/portal/templates/admin/event_list.html
@@ -8,6 +8,11 @@
 {% endblock %}
 
 {% block content %}
+{% if request.query_params.get('error') == 'delete_failed' %}
+<div class="alert alert-danger" style="margin-bottom: 1rem; color: #d32f2f; background-color: #fde0e0; padding: 10px; border-radius: 4px;">
+  <strong>Error:</strong> Failed to delete event due to a database error. The event was not deleted.
+</div>
+{% endif %}
 <div class="toolbar">
   <div>
     <h1 style="font-size:1.6rem; font-weight:800; letter-spacing:-0.02em;">Events</h1>

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -269,6 +269,45 @@ class TestEventCRUD:
             resp = await c.get("/admin/events/99999/", cookies=admin_cookie)
         assert resp.status_code == 404
 
+    @pytest.mark.anyio
+    async def test_delete_event_not_found(self, admin_cookie):
+        async with _client() as c:
+            resp = await c.post(
+                "/admin/events/99999/delete",
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Event not found."
+
+    @pytest.mark.anyio
+    async def test_delete_event_database_error(self, admin_cookie, seed_event, monkeypatch):
+        from sqlalchemy.exc import SQLAlchemyError
+
+        event, _, _ = seed_event
+
+        async def mock_delete_event(session, event_id):
+            raise SQLAlchemyError("Simulated DB failure")
+
+        monkeypatch.setattr("portal.routers.admin.delete_event", mock_delete_event)
+
+        async with _client() as c:
+            resp = await c.post(
+                f"/admin/events/{event.id}/delete",
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/admin/events/?error=delete_failed"
+
+        # Verify redirect page renders error message and event was not deleted
+        async with _client() as c:
+            resp = await c.get("/admin/events/?error=delete_failed", cookies=admin_cookie)
+        assert resp.status_code == 200
+        assert b"Failed to delete event" in resp.content
+        assert b"The event was not deleted." in resp.content
+        assert b"testcon" in resp.content
+
 
 # ---------------------------------------------------------------------------
 # Room CRUD


### PR DESCRIPTION
### Summary of Changes
Fixes #460.

#### Problem
1. When deleting an event via `POST /admin/events/{event_id}/delete`, the endpoint ignored the boolean return value of `delete_event(session, event_id)` and unconditionally redirected to `/admin/events/` with HTTP 303 as if successful, even when the event ID did not exist. In contrast, sibling admin routes (e.g. `GET /admin/events/{event_id}/rooms/`, `GET /admin/events/{event_id}/`) return HTTP 404 for nonexistent resources.
2. The deletion endpoint had no `try ... except` error handling for database operations. Any database failure resulted in an unhandled raw HTTP 500 error page with no feedback indicating whether the deletion occurred.

#### Solution
- **Return 404 on missing event**: Checked the return value of `await delete_event(session, event_id)` in `admin_delete_event`. If `False`, raises `HTTPException(status_code=404, detail="Event not found.")` matching sibling routes.
- **Graceful database error handling**: Wrapped the deletion in a `try ... except` block that preserves `HTTPException`, logs database exceptions via `logger.error`, and safely redirects to `/admin/events/?error=delete_failed`.
- **Admin UI feedback**: Added an alert banner in `portal/templates/admin/event_list.html` that displays:
  > **Error:** Failed to delete event due to a database error. The event was not deleted.
- **Regression tests**: Added `test_delete_event_not_found` and `test_delete_event_database_error` in `tests/test_admin_panel.py`, verifying 404 status for missing events, redirect with error alert upon database failure, and data integrity.

### Verification
- `pytest tests/test_admin_panel.py` (52 passed)
- `pytest tests/test_database.py -k "test_delete_event"` (2 passed)
- `git diff --check` (clean, no whitespace/lint errors)

## Summary by Sourcery

Make admin event deletion report missing events correctly and fail gracefully when database errors prevent deletion.

Bug Fixes:
- Return HTTP 404 when attempting to delete an event that does not exist.
- Handle database failures during event deletion with logging, a safe redirect, and clear admin UI feedback.

Tests:
- Add regression coverage for nonexistent-event deletion, database failures, redirect feedback, and preservation of event data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved admin event deletion handling for missing events and unexpected database failures.
  - Missing events now return a clear not-found response.
  - Failed deletions preserve the event and display an error notification to administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->