### PR TITLE
fix: clear a room's relay pointer when its relay booth is deleted

### DIFF
--- a/portal/database.py
+++ b/portal/database.py
@@ -365,6 +365,14 @@ async def delete_booth(session: AsyncSession, booth_id: int) -> bool:
     booth = await get_booth_by_id(session, booth_id)
     if booth is None:
         return False
+    # rooms.relay_booth_id declares ondelete="SET NULL", but SQLite runs with FKs OFF
+    # so clear it here. Assign the relationship, not the column, so an already-loaded
+    # relay_booth goes too. Left dangling, a reused rowid silently makes the room relay
+    # from whichever booth next takes that id.
+    result = await session.execute(select(Room).where(Room.relay_booth_id == booth_id))
+    for room in result.scalars().all():
+        room.relay_booth = None
+    await session.flush()
     await session.delete(booth)
     await session.flush()
     return True

--- a/portal/templates/interpreter_booth.html
+++ b/portal/templates/interpreter_booth.html
@@ -21,7 +21,7 @@
   data-whep-url='{{ whep_url | default("") }}'
   data-granted-role='{{ granted_role | default("") }}'
   data-display-name='{{ display_name | default("") }}'
-  data-relay-whep-url='{{ relay_whep_url | default("") }}'
+  data-relay-whep-url='{{ relay_whep_url | default("", true) }}'
 >
 
   <!-- ── Top Bar: brand, booth identity, connection, leave ──────────── -->

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -573,16 +573,22 @@ class TestBoothCRUD:
             list_booths_for_room,
         )
 
-        event, room, relay_booth = seed_event
+        # seed_event's booth is where the interpreter sits, so the relay booth is created
+        # after it and holds the highest booth id. Deleting the highest id is what frees it
+        # for reuse; deleting a lower one leaves max() untouched and proves nothing.
+        event, room, own = seed_event
         async with get_session() as s:
-            own = await create_booth(s, event_id=event.id, room_id=room.id, language_code="de", language_name="German")
+            relay_booth = await create_booth(
+                s, event_id=event.id, room_id=room.id, language_code="es", language_name="Spanish"
+            )
             other_room = await create_room(s, event_id=event.id, display_name="Hall B")
-            own_id, other_room_id = own.id, other_room.id
+            own_id, other_room_id, relay_id = own.id, other_room.id, relay_booth.id
+        assert relay_id > own_id
 
         async with _client() as c:
             await c.post(
                 f"/admin/events/{event.id}/rooms/{room.id}/edit",
-                data={"form_section": "relay", "relay_booth_id": str(relay_booth.id)},
+                data={"form_section": "relay", "relay_booth_id": str(relay_id)},
                 cookies=admin_cookie,
                 follow_redirects=False,
             )
@@ -592,16 +598,16 @@ class TestBoothCRUD:
                 role="interpreter",
                 event_slug=event.slug,
                 room_id=room.id,
-                language_code="de",
+                language_code="en",
             )
         }
         async with _client() as c:
-            page = await c.get(f"/interpreter/{event.slug}/{room.id}/de", cookies=session_cookie)
+            page = await c.get(f"/interpreter/{event.slug}/{room.id}/en", cookies=session_cookie)
         assert resolve_relay_attr(page.text) != "", "relay was never configured, so nothing is proven"
 
         async with _client() as c:
             resp = await c.post(
-                f"/admin/events/{event.id}/rooms/{room.id}/booths/{relay_booth.id}/delete",
+                f"/admin/events/{event.id}/rooms/{room.id}/booths/{relay_id}/delete",
                 cookies=admin_cookie,
                 follow_redirects=False,
             )
@@ -616,9 +622,12 @@ class TestBoothCRUD:
         async with get_session() as s:
             new_booth = (await list_booths_for_room(s, other_room_id))[0]
             assert (await get_room_by_id(s, room.id)).relay_booth_id is None
+        # without this the replacement never occupies the freed id and the stale-pointer
+        # path is not exercised at all
+        assert new_booth.id == relay_id, f"no rowid reuse: {new_booth.id} != {relay_id}"
 
         async with _client() as c:
-            page = await c.get(f"/interpreter/{event.slug}/{room.id}/de", cookies=session_cookie)
+            page = await c.get(f"/interpreter/{event.slug}/{room.id}/en", cookies=session_cookie)
         after = resolve_relay_attr(page.text)
         assert f"/{other_room_id}/{new_booth.language_code}/" not in after, after
         assert not after.startswith("http"), f"still handed a relay stream: {after}"

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -71,6 +71,15 @@ async def seed_event():
 # ---------------------------------------------------------------------------
 
 
+def resolve_relay_attr(html: str) -> str:
+    """The relay WHEP URL the interpreter page hands the browser."""
+    import re
+
+    m = re.search(r"data-relay-whep-url='([^']*)'", html)
+    assert m, "the relay attribute is not in the page at all, so a match proves nothing"
+    return m.group(1)
+
+
 def _client():
     from httpx import ASGITransport, AsyncClient
 
@@ -520,6 +529,99 @@ class TestBoothCRUD:
                 follow_redirects=False,
             )
         assert resp.status_code == 303
+
+    @pytest.mark.anyio
+    async def test_delete_relay_booth_clears_the_rooms_pointer(self, admin_cookie, seed_event):
+        """The room page shows Relay Booth as None after the delete; the row must agree."""
+        from portal.database import get_room_by_id, get_session
+
+        event, room, booth = seed_event
+        async with _client() as c:
+            resp = await c.post(
+                f"/admin/events/{event.id}/rooms/{room.id}/edit",
+                data={"form_section": "relay", "relay_booth_id": str(booth.id)},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+            assert resp.status_code == 303
+        async with get_session() as s:
+            assert (await get_room_by_id(s, room.id)).relay_booth_id == booth.id
+
+        async with _client() as c:
+            resp = await c.post(
+                f"/admin/events/{event.id}/rooms/{room.id}/booths/{booth.id}/delete",
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with get_session() as s:
+            assert (await get_room_by_id(s, room.id)).relay_booth_id is None
+
+    @pytest.mark.anyio
+    async def test_deleted_relay_booth_is_not_resurrected_by_a_reused_id(self, admin_cookie, seed_event):
+        """A new booth reusing the deleted booth's rowid must not inherit the relay slot.
+
+        Without the fix the interpreter is handed the new booth's WHEP URL, which can
+        be another room in another language, while the room page still shows None.
+        """
+        from portal.auth import create_participant_token
+        from portal.database import (
+            create_booth,
+            create_room,
+            get_room_by_id,
+            get_session,
+            list_booths_for_room,
+        )
+
+        event, room, relay_booth = seed_event
+        async with get_session() as s:
+            own = await create_booth(s, event_id=event.id, room_id=room.id, language_code="de", language_name="German")
+            other_room = await create_room(s, event_id=event.id, display_name="Hall B")
+            own_id, other_room_id = own.id, other_room.id
+
+        async with _client() as c:
+            await c.post(
+                f"/admin/events/{event.id}/rooms/{room.id}/edit",
+                data={"form_section": "relay", "relay_booth_id": str(relay_booth.id)},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        session_cookie = {
+            "session_token": create_participant_token(
+                booth_id=own_id,
+                role="interpreter",
+                event_slug=event.slug,
+                room_id=room.id,
+                language_code="de",
+            )
+        }
+        async with _client() as c:
+            page = await c.get(f"/interpreter/{event.slug}/{room.id}/de", cookies=session_cookie)
+        assert resolve_relay_attr(page.text) != "", "relay was never configured, so nothing is proven"
+
+        async with _client() as c:
+            resp = await c.post(
+                f"/admin/events/{event.id}/rooms/{room.id}/booths/{relay_booth.id}/delete",
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+            assert resp.status_code == 303
+            # a booth added to the other room can take the freed rowid
+            await c.post(
+                f"/admin/events/{event.id}/rooms/{other_room_id}/booths/",
+                data={"language_code": "fr", "language_name": "French"},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        async with get_session() as s:
+            new_booth = (await list_booths_for_room(s, other_room_id))[0]
+            assert (await get_room_by_id(s, room.id)).relay_booth_id is None
+
+        async with _client() as c:
+            page = await c.get(f"/interpreter/{event.slug}/{room.id}/de", cookies=session_cookie)
+        after = resolve_relay_attr(page.text)
+        assert f"/{other_room_id}/{new_booth.language_code}/" not in after, after
+        assert not after.startswith("http"), f"still handed a relay stream: {after}"
 
     @pytest.mark.anyio
     async def test_booth_not_found(self, admin_cookie, seed_event):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -394,6 +394,76 @@ async def test_delete_booth(db: AsyncSession):
 
 
 @pytest.mark.anyio
+async def test_delete_booth_clears_relay_pointer(db: AsyncSession):
+    """A room relaying from a deleted booth must not keep pointing at its id.
+
+    SQLite reuses rowids, so a left-behind pointer is later satisfied by whatever
+    booth next takes that id, in any room and any language.
+    """
+    ev = await create_event(db, slug="ev-relay-booth-del", display_name="Ev")
+    hall_a = await create_room(db, event_id=ev.id, display_name="Hall A")
+    hall_b = await create_room(db, event_id=ev.id, display_name="Hall B")
+    # Throwaway booths first, so the relay booth's id cannot equal a room id and
+    # hide a filter reading the wrong column.
+    for code in ("de", "es", "it"):
+        await create_booth(db, event_id=ev.id, room_id=hall_b.id, language_code=code, language_name=code)
+    relay = await create_booth(db, event_id=ev.id, room_id=hall_a.id, language_code="en", language_name="English")
+    # both rooms relay from the same booth, so a single-row update would not be enough
+    hall_a.relay_booth_id = relay.id
+    hall_b.relay_booth_id = relay.id
+    await db.flush()
+    # ids must not coincide, or a filter reading the wrong column would still pass
+    assert relay.id not in (hall_a.id, hall_b.id)
+
+    assert await delete_booth(db, relay.id) is True
+    assert await get_booth_by_id(db, relay.id) is None
+    assert (await get_room_by_id(db, hall_a.id)).relay_booth_id is None
+    assert (await get_room_by_id(db, hall_b.id)).relay_booth_id is None
+
+
+@pytest.mark.anyio
+async def test_delete_booth_clears_relay_pointer_when_already_loaded(db: AsyncSession):
+    """Clearing only the column would leave a loaded relay_booth in place."""
+    from sqlalchemy import select as sa_select
+    from sqlalchemy.orm import joinedload
+
+    ev = await create_event(db, slug="ev-relay-booth-loaded", display_name="Ev")
+    room = await create_room(db, event_id=ev.id, display_name="Hall")
+    relay = await create_booth(db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English")
+    room.relay_booth_id = relay.id
+    await db.flush()
+
+    loaded = await db.execute(sa_select(Room).where(Room.id == room.id).options(joinedload(Room.relay_booth)))
+    assert loaded.scalars().first().relay_booth is not None
+
+    assert await delete_booth(db, relay.id) is True
+    fresh = await get_room_by_id(db, room.id)
+    assert fresh.relay_booth_id is None
+    assert fresh.relay_booth is None
+
+
+@pytest.mark.anyio
+async def test_delete_booth_leaves_other_rooms_relay_alone(db: AsyncSession):
+    """Only the rooms relaying from the deleted booth may be touched."""
+    ev = await create_event(db, slug="ev-relay-booth-scope", display_name="Ev")
+    keep_room = await create_room(db, event_id=ev.id, display_name="Keep")
+    drop_room = await create_room(db, event_id=ev.id, display_name="Drop")
+    keep_relay = await create_booth(
+        db, event_id=ev.id, room_id=keep_room.id, language_code="en", language_name="English"
+    )
+    drop_relay = await create_booth(
+        db, event_id=ev.id, room_id=drop_room.id, language_code="fr", language_name="French"
+    )
+    keep_room.relay_booth_id = keep_relay.id
+    drop_room.relay_booth_id = drop_relay.id
+    await db.flush()
+
+    assert await delete_booth(db, drop_relay.id) is True
+    assert (await get_room_by_id(db, drop_room.id)).relay_booth_id is None
+    assert (await get_room_by_id(db, keep_room.id)).relay_booth_id == keep_relay.id
+
+
+@pytest.mark.anyio
 async def test_delete_booth_not_found(db: AsyncSession):
     assert await delete_booth(db, 99999) is False
 

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -171,6 +171,20 @@ def test_interpreter_booth_jitsi_domain_matches_base_url_host():
     assert f"data-jitsi-domain='{expected_host}'".encode() in res.content
 
 
+def test_interpreter_booth_relay_attr_is_empty_when_unconfigured():
+    """A booth with no relay must ship an empty attribute, not the string "None".
+
+    Jinja's ``default("")`` substitutes for an undefined name only, so an explicit
+    None reaches the page as "None". interpreter-booth.js reads the attribute as
+    ``dataset.relayWhepUrl || ''``, where "None" is truthy, so the relay branch runs
+    on a booth that has no relay.
+    """
+    res = client.get("/interpreter/myevent/1/en", cookies=_interpreter_cookie("myevent", "en"))
+    assert res.status_code == 200, res.text
+    assert b"data-relay-whep-url='None'" not in res.content
+    assert b"data-relay-whep-url=''" in res.content
+
+
 def test_auth_token_no_password():
     """When BOOTH_ACCESS_TOKEN is empty, any (or empty) token grants a JWT."""
     res = client.post("/api/auth/token", json={"token": ""})


### PR DESCRIPTION
## Description

Deleting a booth that a room relays from left `rooms.relay_booth_id` pointing at the deleted id.
SQLite reuses rowids, so the next booth created anywhere in the event took that id and silently inherited the relay slot, and the interpreter was served a stream nobody selected.

## Related Issue

Closes #459

## Changes Made

- `delete_booth` clears `relay_booth_id` on any room relaying from the deleted booth. The column already declares `ondelete="SET NULL"`, but `PRAGMA foreign_keys` is 0 on this SQLite setup so nothing enforces it. `delete_room` already works around the same thing a few lines up.
- The relationship is assigned rather than the column, so an already-loaded `relay_booth` is cleared too.
- Separate commit: `interpreter_booth.html` rendered the literal string `None` into `data-relay-whep-url` when no relay was configured, because Jinja's `default("")` substitutes for an undefined name only. `interpreter-booth.js` reads it as `dataset.relayWhepUrl || ''`, where `"None"` is truthy, so `populateRelayDevices()` ran on every booth without a relay. Pre-existing, and drop the commit if you would rather it went separately.

<img width="1088" height="126" alt="image" src="https://github.com/user-attachments/assets/c5080f6d-be4b-410c-98de-fcfe9081131c" />

## Testing

Reproduced and verified end to end against a real server: `alembic upgrade head`, uvicorn, the admin login form, the admin panel for every step, and an interpreter joining through a real `/join/{token}` link.

What the interpreter page handed the browser, same script before and after:

```
                            rooms.relay_booth_id   data-relay-whep-url
relay configured                               2   .../relaybug/1/en/whep
en booth deleted, before fix                   2   .../relaybug/2/fr/whep  <- Hall B, French
en booth deleted, with fix                  None   (empty)
```

The new French booth still takes rowid 2 in both runs, so the id reuse is unchanged; the room simply no longer points at it. The admin room page showed `-- None --` throughout, which is what made this invisible.

- [x] Tested locally
- [x] Existing tests pass - 558 passed
- [x] Added/updated tests - 6 across `test_database.py`, `test_admin_panel.py`, `test_fastapi_app.py`

Reverting `portal/database.py` alone fails the 5 pointer tests and leaves the template test green; reverting the template alone fails only the template test. So each commit is independently covered.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [ ] I have updated documentation where necessary - no docs describe this behaviour
- [x] My changes do not introduce new warnings or errors - `ruff check` clean, `ruff format --check` clean at 94/94

## Additional Notes

Not fixed here, from the issue's Additional Context: `admin_edit_room` assigns `relay_booth_id` straight from the form with no validation, so a booth id from another room, or matching no booth, is stored and redirected as success. The room page's select only ever offers the room's own booths, so that path needs a crafted request rather than normal use. Happy to send it separately if you want it closed.

## Summary by Sourcery

Prevent deleted relay booths from leaving stale room references and triggering unintended interpreter relay streams.

Bug Fixes:
- Clear room relay pointers when their selected booth is deleted, preventing reused booth IDs from silently assigning an unintended relay stream.
- Render an empty relay URL for unconfigured interpreter booths instead of the literal `None`.

Tests:
- Add database, admin-panel, and FastAPI coverage for relay-pointer cleanup, row-ID reuse, loaded relationships, unaffected rooms, and empty relay URL rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relay configuration cleanup when a relay booth is deleted, preventing stale room references.
  * Prevented deleted booth identifiers from exposing replacement booth relay details.
  * Unconfigured relays now render an empty relay URL instead of `"None"`.

* **Tests**
  * Added coverage for relay cleanup across multiple rooms and loaded relationships.
  * Added regression tests for booth identifier reuse and unconfigured relay rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->