### PR TITLE
fix: remove every row scoped to an event when the event is deleted

### DIFF
--- a/portal/database.py
+++ b/portal/database.py
@@ -37,9 +37,14 @@ from portal.models import (
     EventAPIKey,
     EventMembership,
     InviteToken,
+    OAuthAuditLog,
+    OAuthAuthorizationCode,
+    OAuthConsentGrant,
+    OAuthToken,
     Room,
     RoomMembership,
     TranscriptSegment,
+    TranscriptTranslation,
     UsageMetric,
     User,
     generate_token,
@@ -174,12 +179,38 @@ async def delete_event(session: AsyncSession, event_id: int) -> bool:
     ev = await get_event_by_id(session, event_id)
     if ev is None:
         return False
-    # Break the circular FK cycle: rooms.relay_booth_id → booths.id ↔ booths.room_id → rooms.id
-    # assign the relationship, not the column, so an already-loaded relay_booth is
-    # cleared too and the unit of work no longer sees the Room ↔ DBBooth dependency
-    result = await session.execute(select(Room).where(Room.event_id == event_id))
-    for room in result.scalars().all():
+    # SQLite FKs are OFF, so the ondelete= declarations never fire and only children
+    # reachable through an ORM cascade go. Clear the rest explicitly, as delete_room does.
+    room_ids = select(Room.id).where(Room.event_id == event_id)
+    booth_ids = select(DBBooth.id).where(DBBooth.event_id == event_id)
+    segment_ids = select(TranscriptSegment.id).where(TranscriptSegment.room_id.in_(room_ids))
+    token_ids = select(OAuthToken.id).where(OAuthToken.event_id == event_id)
+
+    # Break the rooms.relay_booth_id -> booths.id <-> booths.room_id -> rooms.id cycle.
+    # Scope by booth, not by the room's event: admin_edit_room assigns relay_booth_id
+    # straight from the form, so a room in another event can point at one of these booths.
+    # Assign the relationship rather than the column, or an already-loaded relay_booth
+    # keeps the cycle and the unit of work raises CircularDependencyError.
+    relaying = await session.execute(select(Room).where(Room.relay_booth_id.in_(booth_ids)))
+    for room in relaying.scalars().all():
         room.relay_booth = None
+    await session.flush()
+
+    # oauth_audit_logs is the exception: every foreign key on it is SET NULL and nullable,
+    # so the trail is meant to outlive what it refers to. Null the references rather than
+    # delete the rows, and do it while the tokens still exist so the subquery matches.
+    await session.execute(sa.update(OAuthAuditLog).where(OAuthAuditLog.token_id.in_(token_ids)).values(token_id=None))
+    await session.execute(sa.update(OAuthAuditLog).where(OAuthAuditLog.event_id == event_id).values(event_id=None))
+
+    await session.execute(sa.delete(TranscriptTranslation).where(TranscriptTranslation.segment_id.in_(segment_ids)))
+    await session.execute(sa.delete(TranscriptSegment).where(TranscriptSegment.room_id.in_(room_ids)))
+    await session.execute(sa.delete(RoomMembership).where(RoomMembership.room_id.in_(room_ids)))
+    await session.execute(sa.delete(EventMembership).where(EventMembership.event_id == event_id))
+    await session.execute(sa.delete(OAuthAuthorizationCode).where(OAuthAuthorizationCode.event_id == event_id))
+    await session.execute(sa.delete(OAuthConsentGrant).where(OAuthConsentGrant.event_id == event_id))
+    await session.execute(sa.delete(OAuthToken).where(OAuthToken.event_id == event_id))
+    await session.flush()
+
     await session.delete(ev)
     await session.flush()
     return True

--- a/portal/database.py
+++ b/portal/database.py
@@ -175,11 +175,11 @@ async def delete_event(session: AsyncSession, event_id: int) -> bool:
     if ev is None:
         return False
     # Break the circular FK cycle: rooms.relay_booth_id → booths.id ↔ booths.room_id → rooms.id
-    # null out the back-references so the cascade can order the deletes
+    # assign the relationship, not the column, so an already-loaded relay_booth is
+    # cleared too and the unit of work no longer sees the Room ↔ DBBooth dependency
     result = await session.execute(select(Room).where(Room.event_id == event_id))
     for room in result.scalars().all():
-        room.relay_booth_id = None
-    await session.flush()
+        room.relay_booth = None
     await session.delete(ev)
     await session.flush()
     return True

--- a/portal/database.py
+++ b/portal/database.py
@@ -174,6 +174,12 @@ async def delete_event(session: AsyncSession, event_id: int) -> bool:
     ev = await get_event_by_id(session, event_id)
     if ev is None:
         return False
+    # Break the circular FK cycle: rooms.relay_booth_id → booths.id ↔ booths.room_id → rooms.id
+    # null out the back-references so the cascade can order the deletes
+    result = await session.execute(select(Room).where(Room.event_id == event_id))
+    for room in result.scalars().all():
+        room.relay_booth_id = None
+    await session.flush()
     await session.delete(ev)
     await session.flush()
     return True

--- a/portal/database.py
+++ b/portal/database.py
@@ -32,6 +32,7 @@ from portal.models import (
     AuthToken,
     Base,
     BoothMembership,
+    BoothTranslationLanguage,
     DBBooth,
     Event,
     EventAPIKey,
@@ -214,6 +215,12 @@ async def delete_event(session: AsyncSession, event_id: int) -> bool:
     await session.execute(sa.delete(EventMembership).where(EventMembership.event_id == event_id))
     await session.execute(sa.delete(OAuthAuthorizationCode).where(OAuthAuthorizationCode.event_id == event_id))
     await session.execute(sa.delete(OAuthConsentGrant).where(OAuthConsentGrant.event_id == event_id))
+    # No current path builds a refresh chain across events (oauth.py copies event_id into
+    # the rotated token), but nothing in the schema forbids one, so do not let that
+    # invariant live in another file.
+    await session.execute(
+        sa.update(OAuthToken).where(OAuthToken.parent_token_id.in_(token_ids)).values(parent_token_id=None)
+    )
     await session.execute(sa.delete(OAuthToken).where(OAuthToken.event_id == event_id))
     await session.flush()
 
@@ -280,8 +287,10 @@ async def delete_room(session: AsyncSession, room_id: int) -> bool:
     if room is None:
         return False
     # Break the circular FK cycle: rooms.relay_booth_id → booths.id ↔ booths.room_id → rooms.id
-    # null out relay_booth_id to remove the back-reference
-    room.relay_booth_id = None
+    # Assign the relationship, not the column, so a Room already in the identity map
+    # drops the edge too. Other rooms can relay from this room's booths, so clear those
+    # as well or they point at booths that are about to go.
+    room.relay_booth = None
     await session.flush()
     # delete all booths belonging to this room explicitly
     from sqlalchemy import delete as sa_delete
@@ -289,8 +298,15 @@ async def delete_room(session: AsyncSession, room_id: int) -> bool:
 
     # First delete booth memberships and tokens to avoid orphans since SQLite FKs are OFF
     booth_ids = sa_select(DBBooth.id).where(DBBooth.room_id == room_id)
+    relaying = await session.execute(select(Room).where(Room.relay_booth_id.in_(booth_ids)))
+    for other in relaying.scalars().all():
+        other.relay_booth = None
+    await session.flush()
     await session.execute(sa_delete(BoothMembership).where(BoothMembership.booth_id.in_(booth_ids)))
     await session.execute(sa_delete(InviteToken).where(InviteToken.booth_id.in_(booth_ids)))
+    # sa_delete(DBBooth) below is a Core bulk delete, so the ORM cascade on
+    # DBBooth.translation_languages never runs and these rows would outlive the booths.
+    await session.execute(sa_delete(BoothTranslationLanguage).where(BoothTranslationLanguage.booth_id.in_(booth_ids)))
     # Transcripts and room memberships too, or they outlive the room holding a freed
     # room_id. delete_event only reaches these through the event's rooms, so anything
     # stranded here can never be cleaned up later.

--- a/portal/database.py
+++ b/portal/database.py
@@ -183,14 +183,20 @@ async def delete_event(session: AsyncSession, event_id: int) -> bool:
     # reachable through an ORM cascade go. Clear the rest explicitly, as delete_room does.
     room_ids = select(Room.id).where(Room.event_id == event_id)
     booth_ids = select(DBBooth.id).where(DBBooth.event_id == event_id)
-    segment_ids = select(TranscriptSegment.id).where(TranscriptSegment.room_id.in_(room_ids))
+    # transcript_segments reaches the event through room_id AND booth_id, and the two can
+    # disagree: admin_create_booth takes both ids from the URL without checking that the
+    # room belongs to the event. Predicating on room_id alone leaves a segment whose booth
+    # was ours pointing at a freed booth id.
+    segment_scope = or_(TranscriptSegment.room_id.in_(room_ids), TranscriptSegment.booth_id.in_(booth_ids))
+    segment_ids = select(TranscriptSegment.id).where(segment_scope)
     token_ids = select(OAuthToken.id).where(OAuthToken.event_id == event_id)
 
     # Break the rooms.relay_booth_id -> booths.id <-> booths.room_id -> rooms.id cycle.
     # Scope by booth, not by the room's event: admin_edit_room assigns relay_booth_id
     # straight from the form, so a room in another event can point at one of these booths.
-    # Assign the relationship rather than the column, or an already-loaded relay_booth
-    # keeps the cycle and the unit of work raises CircularDependencyError.
+    # Assign the relationship, not the column. The unit of work builds its delete graph
+    # from mapper state, so a Room still in the identity map keeps the stale edge and
+    # raises CircularDependencyError no matter what the row now says.
     relaying = await session.execute(select(Room).where(Room.relay_booth_id.in_(booth_ids)))
     for room in relaying.scalars().all():
         room.relay_booth = None
@@ -203,7 +209,7 @@ async def delete_event(session: AsyncSession, event_id: int) -> bool:
     await session.execute(sa.update(OAuthAuditLog).where(OAuthAuditLog.event_id == event_id).values(event_id=None))
 
     await session.execute(sa.delete(TranscriptTranslation).where(TranscriptTranslation.segment_id.in_(segment_ids)))
-    await session.execute(sa.delete(TranscriptSegment).where(TranscriptSegment.room_id.in_(room_ids)))
+    await session.execute(sa.delete(TranscriptSegment).where(segment_scope))
     await session.execute(sa.delete(RoomMembership).where(RoomMembership.room_id.in_(room_ids)))
     await session.execute(sa.delete(EventMembership).where(EventMembership.event_id == event_id))
     await session.execute(sa.delete(OAuthAuthorizationCode).where(OAuthAuthorizationCode.event_id == event_id))
@@ -285,6 +291,14 @@ async def delete_room(session: AsyncSession, room_id: int) -> bool:
     booth_ids = sa_select(DBBooth.id).where(DBBooth.room_id == room_id)
     await session.execute(sa_delete(BoothMembership).where(BoothMembership.booth_id.in_(booth_ids)))
     await session.execute(sa_delete(InviteToken).where(InviteToken.booth_id.in_(booth_ids)))
+    # Transcripts and room memberships too, or they outlive the room holding a freed
+    # room_id. delete_event only reaches these through the event's rooms, so anything
+    # stranded here can never be cleaned up later.
+    segment_scope = or_(TranscriptSegment.room_id == room_id, TranscriptSegment.booth_id.in_(booth_ids))
+    segment_ids = select(TranscriptSegment.id).where(segment_scope)
+    await session.execute(sa_delete(TranscriptTranslation).where(TranscriptTranslation.segment_id.in_(segment_ids)))
+    await session.execute(sa_delete(TranscriptSegment).where(segment_scope))
+    await session.execute(sa_delete(RoomMembership).where(RoomMembership.room_id == room_id))
     await session.execute(sa_delete(DBBooth).where(DBBooth.room_id == room_id))
     await session.flush()
     # now safe to delete the room

--- a/portal/routers/admin.py
+++ b/portal/routers/admin.py
@@ -657,7 +657,7 @@ async def admin_event_api_settings_post(
     return safe_redirect(url=f"/admin/events/{event_id}/api-settings/", status_code=status.HTTP_303_SEE_OTHER)
 
 
-@router.post("/admin/events/{event_id}/delete", dependencies=[Depends(require_admin)])
+@router.post("/admin/events/{event_id}/delete", dependencies=[Depends(require_event_owner)])
 async def admin_delete_event(request: Request, event_id: int):
     async with get_session() as session:
         await delete_event(session, event_id)

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -264,6 +264,29 @@ class TestEventCRUD:
         assert b"testcon" not in resp.content
 
     @pytest.mark.anyio
+    async def test_delete_event_with_a_relay_booth(self, admin_cookie, seed_event):
+        """Relay Settings sets rooms.relay_booth_id; the event must still be deletable."""
+        event, room, booth = seed_event
+        async with _client() as c:
+            resp = await c.post(
+                f"/admin/events/{event.id}/rooms/{room.id}/edit",
+                data={"form_section": "relay", "relay_booth_id": str(booth.id)},
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+            assert resp.status_code == 303
+
+            resp = await c.post(
+                f"/admin/events/{event.id}/delete",
+                cookies=admin_cookie,
+                follow_redirects=False,
+            )
+        assert resp.status_code == 303
+        async with _client() as c:
+            resp = await c.get("/admin/events/", cookies=admin_cookie)
+        assert b"testcon" not in resp.content
+
+    @pytest.mark.anyio
     async def test_event_not_found(self, admin_cookie):
         async with _client() as c:
             resp = await c.get("/admin/events/99999/", cookies=admin_cookie)

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -276,6 +276,14 @@ class TestEventCRUD:
             )
             assert resp.status_code == 303
 
+        # 303 alone does not prove the relay was stored, and without it stored
+        # this test would delete an ordinary event and miss the FK cycle.
+        from portal.database import get_room_by_id, get_session
+
+        async with get_session() as s:
+            assert (await get_room_by_id(s, room.id)).relay_booth_id == booth.id
+
+        async with _client() as c:
             resp = await c.post(
                 f"/admin/events/{event.id}/delete",
                 cookies=admin_cookie,

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -295,6 +295,55 @@ class TestEventCRUD:
         assert b"testcon" not in resp.content
 
     @pytest.mark.anyio
+    async def test_delete_event_rejects_a_room_coordinator(self, admin_cookie, seed_event):
+        """require_admin admits a room_coordinator for the whole event, and deleting one
+        now destroys transcripts and OAuth grant state. Match the API-key routes and
+        require an event owner."""
+        from portal.auth import create_user_token
+        from portal.database import create_room, create_user, get_session
+        from portal.models import RoomMembership
+
+        event, room, _ = seed_event
+        async with get_session() as s:
+            side = await create_room(s, event_id=event.id, display_name="Side Room")
+            carol = await create_user(s, email="carol@example.com", display_name="Carol")
+            s.add(RoomMembership(user_id=carol.id, room_id=side.id, role="room_coordinator"))
+            carol_id = carol.id
+
+        cookie = {"user_token": create_user_token(user_id=carol_id, email="carol@example.com")}
+        async with _client() as c:
+            # she really is a coordinator: her own room's page is allowed
+            allowed = await c.get(f"/admin/events/{event.id}/rooms/{side.id}/", cookies=cookie)
+            resp = await c.post(f"/admin/events/{event.id}/delete", cookies=cookie, follow_redirects=False)
+        assert allowed.status_code == 200, "fixture is wrong; she is not a coordinator"
+        assert resp.status_code == 403
+
+        from portal.database import get_event_by_id
+
+        async with get_session() as s:
+            assert await get_event_by_id(s, event.id) is not None
+
+    @pytest.mark.anyio
+    async def test_delete_event_allows_an_event_owner(self, seed_event):
+        """The tightened guard must still admit the event's own owner."""
+        from portal.auth import create_user_token
+        from portal.database import create_user, get_event_by_id, get_session
+        from portal.models import EventMembership
+
+        event, _, _ = seed_event
+        async with get_session() as s:
+            owner = await create_user(s, email="owner@example.com", display_name="Owner")
+            s.add(EventMembership(user_id=owner.id, event_id=event.id, role="event_owner"))
+            owner_id = owner.id
+
+        cookie = {"user_token": create_user_token(user_id=owner_id, email="owner@example.com")}
+        async with _client() as c:
+            resp = await c.post(f"/admin/events/{event.id}/delete", cookies=cookie, follow_redirects=False)
+        assert resp.status_code == 303
+        async with get_session() as s:
+            assert await get_event_by_id(s, event.id) is None
+
+    @pytest.mark.anyio
     async def test_event_not_found(self, admin_cookie):
         async with _client() as c:
             resp = await c.get("/admin/events/99999/", cookies=admin_cookie)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -159,23 +159,59 @@ async def test_delete_event(db: AsyncSession):
 @pytest.mark.anyio
 async def test_delete_event_with_a_relay_booth(db: AsyncSession):
     """rooms.relay_booth_id points at a booth that points back at the room."""
+    # A throwaway event with its own rooms first, so the target event's id cannot
+    # coincide with any of its room ids and hide a filter reading the wrong column.
+    other = await create_event(db, slug="ev-offset", display_name="Offset")
+    for i in range(3):
+        await create_room(db, event_id=other.id, display_name=f"Other {i}")
     ev = await create_event(db, slug="ev-relay-del", display_name="Ev")
+    rooms = []
+    for code, name in (("en", "English"), ("es", "Spanish"), ("fr", "French")):
+        room = await create_room(db, event_id=ev.id, display_name=f"Room {code}")
+        booth = await create_booth(
+            db, event_id=ev.id, room_id=room.id, language_code=code, language_name=name
+        )
+        room.relay_booth_id = booth.id
+        db.add(InviteToken(booth_id=booth.id, token=generate_token(), role="interpreter"))
+        rooms.append((room, booth))
+    await db.flush()
+    assert all(room.id != ev.id for room, _ in rooms)
+
+    for room, booth in rooms:
+        assert len(await list_booths_for_room(db, room.id)) == 1
+        assert len(await list_tokens_for_booth(db, booth.id)) == 1
+
+    assert await delete_event(db, ev.id) is True
+    assert await get_event_by_id(db, ev.id) is None
+    for room, booth in rooms:
+        assert await get_room_by_id(db, room.id) is None
+        assert await get_booth_by_id(db, booth.id) is None
+        assert await list_booths_for_room(db, room.id) == []
+        assert await list_tokens_for_booth(db, booth.id) == []
+
+
+@pytest.mark.anyio
+async def test_delete_event_with_a_relay_booth_already_loaded(db: AsyncSession):
+    """Clearing only the column would leave the loaded relationship holding the cycle."""
+    from sqlalchemy import select as sa_select
+    from sqlalchemy.orm import joinedload
+
+    ev = await create_event(db, slug="ev-relay-loaded", display_name="Ev")
     room = await create_room(db, event_id=ev.id, display_name="Room")
     booth = await create_booth(
         db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English"
     )
     room.relay_booth_id = booth.id
-    db.add(InviteToken(booth_id=booth.id, token=generate_token(), role="interpreter"))
     await db.flush()
 
-    assert len(await list_booths_for_room(db, room.id)) == 1
-    assert len(await list_tokens_for_booth(db, booth.id)) == 1
+    loaded = await db.execute(
+        sa_select(Room).where(Room.id == room.id).options(joinedload(Room.relay_booth))
+    )
+    assert loaded.scalars().first().relay_booth is not None
 
     assert await delete_event(db, ev.id) is True
     assert await get_event_by_id(db, ev.id) is None
     assert await get_room_by_id(db, room.id) is None
-    assert await list_booths_for_room(db, room.id) == []
-    assert await list_tokens_for_booth(db, booth.id) == []
 
 
 @pytest.mark.anyio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -168,9 +168,7 @@ async def test_delete_event_with_a_relay_booth(db: AsyncSession):
     rooms = []
     for code, name in (("en", "English"), ("es", "Spanish"), ("fr", "French")):
         room = await create_room(db, event_id=ev.id, display_name=f"Room {code}")
-        booth = await create_booth(
-            db, event_id=ev.id, room_id=room.id, language_code=code, language_name=name
-        )
+        booth = await create_booth(db, event_id=ev.id, room_id=room.id, language_code=code, language_name=name)
         room.relay_booth_id = booth.id
         db.add(InviteToken(booth_id=booth.id, token=generate_token(), role="interpreter"))
         rooms.append((room, booth))
@@ -198,15 +196,11 @@ async def test_delete_event_with_a_relay_booth_already_loaded(db: AsyncSession):
 
     ev = await create_event(db, slug="ev-relay-loaded", display_name="Ev")
     room = await create_room(db, event_id=ev.id, display_name="Room")
-    booth = await create_booth(
-        db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English"
-    )
+    booth = await create_booth(db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English")
     room.relay_booth_id = booth.id
     await db.flush()
 
-    loaded = await db.execute(
-        sa_select(Room).where(Room.id == room.id).options(joinedload(Room.relay_booth))
-    )
+    loaded = await db.execute(sa_select(Room).where(Room.id == room.id).options(joinedload(Room.relay_booth)))
     assert loaded.scalars().first().relay_booth is not None
 
     assert await delete_event(db, ev.id) is True

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -157,6 +157,22 @@ async def test_delete_event(db: AsyncSession):
 
 
 @pytest.mark.anyio
+async def test_delete_event_with_a_relay_booth(db: AsyncSession):
+    """rooms.relay_booth_id points at a booth that points back at the room."""
+    ev = await create_event(db, slug="ev-relay-del", display_name="Ev")
+    room = await create_room(db, event_id=ev.id, display_name="Room")
+    booth = await create_booth(
+        db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English"
+    )
+    room.relay_booth_id = booth.id
+    await db.flush()
+
+    assert await delete_event(db, ev.id) is True
+    assert await get_event_by_id(db, ev.id) is None
+    assert await get_room_by_id(db, room.id) is None
+
+
+@pytest.mark.anyio
 async def test_delete_event_not_found(db: AsyncSession):
     assert await delete_event(db, 99999) is False
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 
 import pytest
+import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 # We import CRUD helpers and test them against our isolated test DB.
@@ -38,7 +39,17 @@ from portal.database import (
     list_users,
     redeem_invite_token,
 )
-from portal.models import Base, DBBooth, Event, InviteToken, Room, generate_token, utc_now
+from portal.models import (
+    Base,
+    DBBooth,
+    Event,
+    InviteToken,
+    Room,
+    TranscriptSegment,
+    TranscriptTranslation,
+    generate_token,
+    utc_now,
+)
 from portal.roles import ALL_ROLES
 
 # ---------------------------------------------------------------------------
@@ -897,6 +908,66 @@ async def test_delete_event_clears_a_cross_event_relay_pointer(db: AsyncSession)
     fresh = await get_room_by_id(db, survivor_room.id)
     assert fresh is not None, "the surviving event's room must not be deleted"
     assert fresh.relay_booth_id is None
+
+
+@pytest.mark.anyio
+async def test_delete_event_removes_a_segment_reached_only_by_its_booth(db: AsyncSession):
+    """transcript_segments reaches the event by room_id AND booth_id, and they can differ.
+
+    admin_create_booth takes both ids from the URL without checking that the room belongs
+    to the event, so a booth owned here can sit in another event's room. Predicating on
+    room_id alone leaves the segment pointing at a booth id SQLite is free to reuse.
+    """
+    other = await create_event(db, slug="ev-seg-other", display_name="Other")
+    other_room = await create_room(db, event_id=other.id, display_name="Other Hall")
+    ev = await create_event(db, slug="ev-seg-owner", display_name="Owner")
+    # booth owned by ev, sitting in the other event's room
+    booth = await create_booth(db, event_id=ev.id, room_id=other_room.id, language_code="en", language_name="English")
+    seg = TranscriptSegment(room_id=other_room.id, booth_id=booth.id, language_code="en", text="cross")
+    db.add(seg)
+    await db.flush()
+    seg_id = seg.id
+
+    assert await delete_event(db, ev.id) is True
+    assert await get_booth_by_id(db, booth.id) is None
+    assert (
+        await db.execute(sa.select(TranscriptSegment).where(TranscriptSegment.id == seg_id))
+    ).scalars().first() is None
+    # the other event's room is untouched
+    assert await get_room_by_id(db, other_room.id) is not None
+
+
+@pytest.mark.anyio
+async def test_delete_room_removes_its_transcripts_and_memberships(db: AsyncSession):
+    """Anything delete_room strands can never be reached again.
+
+    delete_event only finds these rows through the event's rooms, so a row left behind
+    here outlives the event too, holding a room_id SQLite can hand out again.
+    """
+    from portal.database import create_user
+    from portal.models import RoomMembership
+
+    ev = await create_event(db, slug="ev-room-purge", display_name="Ev")
+    room = await create_room(db, event_id=ev.id, display_name="Hall")
+    booth = await create_booth(db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English")
+    user = await create_user(db, email="rp@example.com", display_name="RP")
+    db.add(RoomMembership(user_id=user.id, room_id=room.id, role="room_coordinator"))
+    seg = TranscriptSegment(room_id=room.id, booth_id=booth.id, language_code="en", text="hi")
+    db.add(seg)
+    await db.flush()
+    db.add(TranscriptTranslation(segment_id=seg.id, language_code="es", text="hola"))
+    await db.flush()
+    room_id, seg_id = room.id, seg.id
+
+    assert await delete_room(db, room_id) is True
+    left_seg = (await db.execute(sa.select(TranscriptSegment).where(TranscriptSegment.id == seg_id))).scalars().all()
+    left_tr = (
+        (await db.execute(sa.select(TranscriptTranslation).where(TranscriptTranslation.segment_id == seg_id)))
+        .scalars()
+        .all()
+    )
+    left_rm = (await db.execute(sa.select(RoomMembership).where(RoomMembership.room_id == room_id))).scalars().all()
+    assert (left_seg, left_tr, left_rm) == ([], [], [])
 
 
 @pytest.mark.anyio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -165,11 +165,17 @@ async def test_delete_event_with_a_relay_booth(db: AsyncSession):
         db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English"
     )
     room.relay_booth_id = booth.id
+    db.add(InviteToken(booth_id=booth.id, token=generate_token(), role="interpreter"))
     await db.flush()
+
+    assert len(await list_booths_for_room(db, room.id)) == 1
+    assert len(await list_tokens_for_booth(db, booth.id)) == 1
 
     assert await delete_event(db, ev.id) is True
     assert await get_event_by_id(db, ev.id) is None
     assert await get_room_by_id(db, room.id) is None
+    assert await list_booths_for_room(db, room.id) == []
+    assert await list_tokens_for_booth(db, booth.id) == []
 
 
 @pytest.mark.anyio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -682,6 +682,237 @@ async def test_cascade_delete_event_removes_rooms_and_booths(db: AsyncSession):
     assert await get_booth_by_id(db, booth.id) is None
 
 
+async def _seed_event_with_every_scoped_row(db: AsyncSession, slug: str) -> dict:
+    """Seed one row in every table that becomes unreachable when the event is deleted."""
+    from portal.database import create_user
+    from portal.models import (
+        BoothMembership,
+        BoothTranslationLanguage,
+        DeveloperAccount,
+        EventAPIKey,
+        EventMembership,
+        OAuthAuditLog,
+        OAuthAuthorizationCode,
+        OAuthClient,
+        OAuthConsentGrant,
+        OAuthToken,
+        RoomMembership,
+        RoomTranslationLanguage,
+        TranscriptSegment,
+        TranscriptTranslation,
+        UsageMetric,
+    )
+
+    now = utc_now()
+    ev = await create_event(db, slug=slug, display_name=slug)
+    room = await create_room(db, event_id=ev.id, display_name=f"{slug} Hall")
+    booth = await create_booth(db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English")
+    user = await create_user(db, email=f"{slug}@example.com", display_name=slug)
+    await create_invite_token(db, booth_id=booth.id, role="interpreter")
+    db.add_all(
+        [
+            BoothMembership(user_id=user.id, booth_id=booth.id, role="interpreter"),
+            EventMembership(user_id=user.id, event_id=ev.id, role="event_owner"),
+            RoomMembership(user_id=user.id, room_id=room.id, role="room_coordinator"),
+            RoomTranslationLanguage(room_id=room.id, language_code="es", language_name="Spanish"),
+            BoothTranslationLanguage(booth_id=booth.id, language_code="es", language_name="Spanish"),
+            EventAPIKey(event_id=ev.id, name=slug, preview="pfx", key_hash=generate_token()),
+            UsageMetric(event_id=ev.id, metric_name="minutes", value=1),
+        ]
+    )
+    seg = TranscriptSegment(room_id=room.id, booth_id=booth.id, language_code="en", text="hello")
+    db.add(seg)
+    await db.flush()
+    db.add(TranscriptTranslation(segment_id=seg.id, language_code="es", text="hola"))
+
+    dev = DeveloperAccount(user_id=user.id, organization_name=slug)
+    db.add(dev)
+    await db.flush()
+    client = OAuthClient(developer_account_id=dev.id, client_id=f"cid-{slug}", name=slug)
+    db.add(client)
+    await db.flush()
+    tok = OAuthToken(
+        client_id=client.id,
+        user_id=user.id,
+        event_id=ev.id,
+        access_token_hash=generate_token(),
+        expires_at=now + timedelta(hours=1),
+    )
+    db.add(tok)
+    await db.flush()
+    db.add_all(
+        [
+            OAuthAuditLog(
+                token_id=tok.id,
+                client_id=client.id,
+                event_id=ev.id,
+                action="token.issued",
+                request_path="/oauth/token",
+                status_code=200,
+            ),
+            OAuthConsentGrant(client_id=client.id, user_id=user.id, event_id=ev.id),
+            OAuthAuthorizationCode(
+                client_id=client.id,
+                user_id=user.id,
+                event_id=ev.id,
+                code_hash=generate_token(),
+                code_challenge="c" * 43,
+                code_challenge_method="S256",
+                redirect_uri="https://example.com/cb",
+                expires_at=now + timedelta(minutes=5),
+            ),
+        ]
+    )
+    await db.flush()
+    return {
+        "event": ev.id,
+        "room": room.id,
+        "booth": booth.id,
+        "user": user.id,
+        "segment": seg.id,
+        "token": tok.id,
+        "client": client.id,
+    }
+
+
+async def _scoped_row_counts(db: AsyncSession, ids: dict) -> dict[str, int]:
+    """Count rows still tied to this event, room, booth or segment."""
+    from sqlalchemy import text
+
+    queries = {
+        "events": ("events", "id = :event"),
+        "rooms": ("rooms", "event_id = :event"),
+        "booths": ("booths", "event_id = :event"),
+        "invite_tokens": ("invite_tokens", "booth_id = :booth"),
+        "booth_memberships": ("booth_memberships", "booth_id = :booth"),
+        "booth_translation_languages": ("booth_translation_languages", "booth_id = :booth"),
+        "room_translation_languages": ("room_translation_languages", "room_id = :room"),
+        "event_api_keys": ("event_api_keys", "event_id = :event"),
+        "usage_metrics": ("usage_metrics", "event_id = :event"),
+        "transcript_segments": ("transcript_segments", "room_id = :room"),
+        "transcript_translations": ("transcript_translations", "segment_id = :segment"),
+        "event_memberships": ("event_memberships", "event_id = :event"),
+        "room_memberships": ("room_memberships", "room_id = :room"),
+        "oauth_tokens": ("oauth_tokens", "event_id = :event"),
+        "oauth_consent_grants": ("oauth_consent_grants", "event_id = :event"),
+        "oauth_authorization_codes": ("oauth_authorization_codes", "event_id = :event"),
+        "oauth_audit_logs": ("oauth_audit_logs", "event_id = :event OR token_id = :token"),
+    }
+    out = {}
+    for label, (table, where) in queries.items():
+        out[label] = (await db.execute(text(f"SELECT COUNT(*) FROM {table} WHERE {where}"), ids)).scalar()
+    return out
+
+
+@pytest.mark.anyio
+async def test_delete_event_removes_every_scoped_row(db: AsyncSession):
+    """PRAGMA foreign_keys is 0, so ondelete= never fires and only ORM cascades run.
+
+    Everything scoped to the event must still go, or the rows outlive it and a reused
+    id later resolves them against unrelated data.
+    """
+    ids = await _seed_event_with_every_scoped_row(db, "purge")
+    before = await _scoped_row_counts(db, ids)
+    assert all(n == 1 for n in before.values()), before
+
+    assert await delete_event(db, ids["event"]) is True
+    after = await _scoped_row_counts(db, ids)
+    assert after == dict.fromkeys(before, 0), {k: v for k, v in after.items() if v}
+
+
+@pytest.mark.anyio
+async def test_delete_event_keeps_the_oauth_audit_trail(db: AsyncSession):
+    """oauth_audit_logs has SET NULL on every foreign key, so the row outlives the event.
+
+    Deleting the rows instead would destroy an audit trail the schema asks us to keep.
+    """
+    from sqlalchemy import text
+
+    ids = await _seed_event_with_every_scoped_row(db, "audit")
+    assert await delete_event(db, ids["event"]) is True
+
+    rows = (await db.execute(text("SELECT token_id, client_id, event_id, action FROM oauth_audit_logs"))).all()
+    assert len(rows) == 1, rows
+    token_id, client_id, event_id, action = rows[0]
+    assert (token_id, event_id) == (None, None)
+    assert action == "token.issued"
+    # the client is not event scoped, so its reference must survive untouched
+    assert client_id == ids["client"]
+
+
+@pytest.mark.anyio
+async def test_delete_event_with_its_own_relay_booth(db: AsyncSession):
+    """rooms.relay_booth_id -> booths.id and booths.room_id -> rooms.id form a cycle.
+
+    Clearing the pointer first is what lets the unit of work order the deletes at all.
+    """
+    ev = await create_event(db, slug="ev-own-relay", display_name="Ev")
+    room = await create_room(db, event_id=ev.id, display_name="Hall")
+    booth = await create_booth(db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English")
+    room.relay_booth_id = booth.id
+    await db.flush()
+
+    assert await delete_event(db, ev.id) is True
+    assert await get_event_by_id(db, ev.id) is None
+    assert await get_room_by_id(db, room.id) is None
+    assert await get_booth_by_id(db, booth.id) is None
+
+
+@pytest.mark.anyio
+async def test_delete_event_with_its_own_relay_booth_already_loaded(db: AsyncSession):
+    """Same cycle, but with the relay_booth relationship already in the identity map."""
+    from sqlalchemy import select as sa_select
+    from sqlalchemy.orm import joinedload
+
+    ev = await create_event(db, slug="ev-own-relay-loaded", display_name="Ev")
+    room = await create_room(db, event_id=ev.id, display_name="Hall")
+    booth = await create_booth(db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English")
+    room.relay_booth_id = booth.id
+    await db.flush()
+    loaded = await db.execute(sa_select(Room).where(Room.id == room.id).options(joinedload(Room.relay_booth)))
+    assert loaded.scalars().first().relay_booth is not None
+
+    assert await delete_event(db, ev.id) is True
+    assert await get_room_by_id(db, room.id) is None
+
+
+@pytest.mark.anyio
+async def test_delete_event_clears_a_cross_event_relay_pointer(db: AsyncSession):
+    """admin_edit_room stores relay_booth_id unvalidated, so it can cross events.
+
+    Scoping the clear by the room's event instead of by booth would leave the surviving
+    event's room pointing at a booth that no longer exists.
+    """
+    survivor = await create_event(db, slug="ev-survivor", display_name="Survivor")
+    doomed = await create_event(db, slug="ev-doomed", display_name="Doomed")
+    survivor_room = await create_room(db, event_id=survivor.id, display_name="Survivor Hall")
+    doomed_room = await create_room(db, event_id=doomed.id, display_name="Doomed Hall")
+    doomed_booth = await create_booth(
+        db, event_id=doomed.id, room_id=doomed_room.id, language_code="en", language_name="English"
+    )
+    survivor_room.relay_booth_id = doomed_booth.id
+    await db.flush()
+
+    assert await delete_event(db, doomed.id) is True
+    fresh = await get_room_by_id(db, survivor_room.id)
+    assert fresh is not None, "the surviving event's room must not be deleted"
+    assert fresh.relay_booth_id is None
+
+
+@pytest.mark.anyio
+async def test_delete_event_leaves_another_events_rows_alone(db: AsyncSession):
+    """A subquery reading the wrong column would purge every event, not just this one."""
+    keep = await _seed_event_with_every_scoped_row(db, "keep")
+    drop = await _seed_event_with_every_scoped_row(db, "drop")
+    assert keep["event"] != drop["event"]
+
+    keep_before = await _scoped_row_counts(db, keep)
+    assert await delete_event(db, drop["event"]) is True
+
+    assert await _scoped_row_counts(db, drop) == dict.fromkeys(keep_before, 0)
+    assert await _scoped_row_counts(db, keep) == keep_before
+
+
 @pytest.mark.anyio
 async def test_cascade_delete_room_removes_booths(db: AsyncSession):
     ev = await create_event(db, slug="ev-cascade2", display_name="Ev")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -971,6 +971,88 @@ async def test_delete_room_removes_its_transcripts_and_memberships(db: AsyncSess
 
 
 @pytest.mark.anyio
+async def test_delete_room_removes_booth_translation_languages(db: AsyncSession):
+    """The booth delete in delete_room is a Core bulk delete, so no ORM cascade runs."""
+    from portal.models import BoothTranslationLanguage
+
+    ev = await create_event(db, slug="ev-btl", display_name="Ev")
+    room = await create_room(db, event_id=ev.id, display_name="Hall")
+    booth = await create_booth(db, event_id=ev.id, room_id=room.id, language_code="en", language_name="English")
+    db.add(BoothTranslationLanguage(booth_id=booth.id, language_code="es", language_name="Spanish"))
+    await db.flush()
+
+    assert await delete_room(db, room.id) is True
+    left = (
+        (await db.execute(sa.select(BoothTranslationLanguage).where(BoothTranslationLanguage.booth_id == booth.id)))
+        .scalars()
+        .all()
+    )
+    assert left == []
+
+
+@pytest.mark.anyio
+async def test_delete_room_clears_another_rooms_relay_pointer(db: AsyncSession):
+    """A second room can relay from this room's booths; those pointers go too."""
+    ev = await create_event(db, slug="ev-relay-rm", display_name="Ev")
+    doomed = await create_room(db, event_id=ev.id, display_name="Doomed")
+    other = await create_room(db, event_id=ev.id, display_name="Other")
+    booth = await create_booth(db, event_id=ev.id, room_id=doomed.id, language_code="en", language_name="English")
+    other.relay_booth_id = booth.id
+    await db.flush()
+
+    assert await delete_room(db, doomed.id) is True
+    fresh = await get_room_by_id(db, other.id)
+    assert fresh is not None
+    assert fresh.relay_booth_id is None
+
+
+@pytest.mark.anyio
+async def test_delete_event_clears_a_cross_event_parent_token(db: AsyncSession):
+    """oauth_tokens.parent_token_id is SET NULL, which SQLite never enforces.
+
+    No current path builds a chain across events, so this guards the invariant rather
+    than a reachable bug.
+    """
+    from portal.database import create_user
+    from portal.models import DeveloperAccount, OAuthClient, OAuthToken
+
+    doomed = await create_event(db, slug="ev-tok-doomed", display_name="Doomed")
+    keep = await create_event(db, slug="ev-tok-keep", display_name="Keep")
+    user = await create_user(db, email="tok@example.com", display_name="Tok")
+    dev = DeveloperAccount(user_id=user.id, organization_name="Org")
+    db.add(dev)
+    await db.flush()
+    client = OAuthClient(developer_account_id=dev.id, client_id="cid-tok", name="Tok")
+    db.add(client)
+    await db.flush()
+    parent = OAuthToken(
+        client_id=client.id,
+        user_id=user.id,
+        event_id=doomed.id,
+        access_token_hash=generate_token(),
+        expires_at=utc_now() + timedelta(hours=1),
+    )
+    db.add(parent)
+    await db.flush()
+    child = OAuthToken(
+        client_id=client.id,
+        user_id=user.id,
+        event_id=keep.id,
+        access_token_hash=generate_token(),
+        parent_token_id=parent.id,
+        expires_at=utc_now() + timedelta(hours=1),
+    )
+    db.add(child)
+    await db.flush()
+    child_id = child.id
+
+    assert await delete_event(db, doomed.id) is True
+    fresh = (await db.execute(sa.select(OAuthToken).where(OAuthToken.id == child_id))).scalars().first()
+    assert fresh is not None, "the surviving event's token must not be deleted"
+    assert fresh.parent_token_id is None
+
+
+@pytest.mark.anyio
 async def test_delete_event_leaves_another_events_rows_alone(db: AsyncSession):
     """A subquery reading the wrong column would purge every event, not just this one."""
     keep = await _seed_event_with_every_scoped_row(db, "keep")


### PR DESCRIPTION
## Description

**Update after rebasing on main (read this first).**
#457, which this PR was stacked on, has been squash merged as `0204679`, so the diff below is now only this PR's own four commits.
#477 has also merged, and it turns on `PRAGMA foreign_keys=ON` for every engine the app creates.
The original premise of this PR was that SQLite never enforces the `ondelete=` rules, and that is no longer true on main.
I re-measured everything against current main instead of reusing the old numbers, and the honest result is:

- **The orphan cleanup is no longer needed by the running app.**
  On current main, deleting an event through the admin panel already leaves 0 orphaned rows, because the database now cascades the deletes itself.
  The explicit statements in this PR still run and still pass, but on the app's own engine they now duplicate what SQLite does.
- **The permission fix is still needed.**
  On main, a `room_coordinator` of one side room can still delete the whole event, and with #477 that now destroys every transcript, membership and OAuth grant for it.
  This PR returns 403 for that and touches nothing.

So this PR is now mainly the guard change, with the orphan cleanup as defense in depth.
I am happy to go either way: keep it as is, or cut it down to the guard change and its two tests and drop the `delete_event` / `delete_room` changes.
Just say which.

## Related Issue

Closes #458.
The reachable part of #458 is already fixed on main by #477.
This PR adds explicit cleanup on top of that, so it does not depend on the pragma being set.

## Changes Made

**1. `POST /admin/events/{id}/delete` requires the event owner** (`portal/routers/admin.py`).
It used `require_admin`, which admits a `room_coordinator` of any single room as an admin for the whole event.
It now uses `require_event_owner`, which the API key routes on the same resource already use.
That still admits the `admin_token`, a site admin and the event's own owner.
Only the coordinator case changes.

**2. `delete_event` and `delete_room` clear their scoped rows explicitly** (`portal/database.py`).
When this was written, `PRAGMA foreign_keys` was 0, so only children reachable through an ORM cascade were removed and eight tables kept rows pointing at freed ids.
With #477 the database handles that on the app engine, so this is now a second layer rather than the fix.
It does still cover any engine created without the pragma.
Right now that means only the test fixtures, since `_get_engine()` and `configure()` both set it.
Three of the cases need more than a plain delete by `event_id`:

- **`oauth_audit_logs` is updated, not deleted.**
  All three of its foreign keys are `SET NULL` and nullable, so the audit row is meant to outlive what it refers to.
  `event_id` and `token_id` are nulled in two separate statements, because one statement with an `OR` would damage a second event's rows.
  `client_id` is not event scoped and is left alone.
- **`transcript_segments` is scoped by `room_id` OR `booth_id`.**
  It reaches the event through both, and they can disagree because `admin_create_booth` takes both ids from the URL without checking that the room belongs to the event.
- **`rooms.relay_booth_id` is scoped by booth, not by the room's event**, for the same unvalidated form reason via `admin_edit_room`.
  The relationship is assigned rather than the column, so a `Room` already in the session drops the edge too.

One effect of this code that the pragma does not give you: it also clears these pointers on objects already loaded in the current session.
With only the database `SET NULL`, a `Room` or `OAuthToken` loaded earlier in the same session still shows the old id until it is refreshed.
Every request gets a fresh session, so this does not reach users today.

The code comments in `delete_event` and `delete_room` still say SQLite FKs are OFF.
That is now out of date, and I will reword or remove them depending on which way you want to take this PR.

## Testing

End to end on a real uvicorn server, with an alembic-migrated SQLite database, a real admin login through `/admin/login` and a real coordinator login through `/login`.
The database was seeded with two identical events, so over-deletion would show.
The event being deleted has its own relay booth, and the surviving event has a room relaying one of its booths.

| | current `main` (with #477) | this PR |
|---|---|---|
| `room_coordinator` of one side room deletes the event | **303, whole event deleted** | **403, nothing touched** |
| admin deletes the event | 303 | 303 |
| rows left scoped to the deleted event | 0 | 0 |
| orphaned rows anywhere | 0 | 0 |
| `PRAGMA foreign_key_check` | empty | empty |
| surviving event's rows | all intact | all intact |
| surviving room's cross-event relay pointer | nulled | nulled |

I also ran this PR's new tests against main's code:

- All 10 fail on main with the tests exactly as written. 9 are in `tests/test_database.py`, whose `db` fixture builds its own engine without the pragma, so they test the explicit cleanup rather than what production does.
  The 10th is `test_delete_event_rejects_a_room_coordinator`, which fails for the real reason.
- When that fixture turns the pragma on the way `portal/database.py` does, 6 of the 9 pass on main.
  The other 3 fail only because an object loaded earlier in the same session still shows the old id, as described above.
  That run also produces 71 teardown errors, because `Base.metadata.drop_all` hits the existing `booths` <-> `rooms` cycle once foreign keys are on.
  The `db` fixture no longer matches production and would need that fixed first.

The screenshot below is from the original run, before #477 merged.

<img width="2834" height="990" alt="image" src="https://github.com/user-attachments/assets/4b09b409-4633-4c16-97ee-29df5f9edfdc" />

- [x] Tested locally, end to end as above
- [x] Existing tests pass: 572 passed on this branch after the rebase
- [x] Added/updated tests: 8 in `tests/test_database.py` and 2 in `tests/test_admin_panel.py`
- [x] CI green after the rebase

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [ ] I have updated documentation where necessary - no docs describe this behaviour
- [x] My changes do not introduce new warnings or errors - `ruff check` clean.
  `ruff format --check` now reports 25 files on main, all from other merged PRs (including the pragma blocks #477 added to `portal/database.py`); none of them are lines this PR changes.

## Additional Notes

- **An event soft-deleted through the v1 API can never be hard-deleted.**
  `DELETE /api/v1/events/{slug}` sets `deleted_at`, and `get_event_by_id` filters `deleted_at IS NULL`, so `delete_event` returns `False` while `admin_delete_event` discards the return and redirects as if it succeeded.
  This is pre-existing and still true on main; #460 tracks the discarded return value.
- **`delete_event` can still destroy another event's booth** when that booth sits in one of this event's rooms, through the existing `Event.rooms -> Room.booths` cascade.
  This behaves the same before and after this PR.
- `admin_edit_room` and `admin_create_booth` still store unvalidated ids, which is the root of both cross-event cases above.
  Worth closing separately; I did not touch those routes here.

## Summary by Sourcery

Prevent unauthorized event deletion and comprehensively clean up event- and room-scoped data without affecting surviving events.

Bug Fixes:
- Restrict event deletion to event owners, site administrators, and the admin token so room coordinators cannot delete an entire event.
- Ensure deleting events or rooms removes all associated memberships, transcripts, OAuth records, translation data, and other scoped rows while preserving OAuth audit history.
- Clear relay-booth references, including cross-event references, before deleting rooms or events to prevent stale pointers and deletion failures.

Enhancements:
- Add comprehensive coverage for scoped-row cleanup, OAuth audit preservation, relay relationships, cross-event references, and deletion authorization.

Tests:
- Add database and admin-panel tests covering event and room cleanup boundaries and event-owner authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting events or rooms now reliably removes associated memberships, transcripts, translations, and authorization records without leaving orphaned data.
  * Event deletion now works correctly with relay booth configurations, including cross-event links and complex booth relationships.
  * Related token references are cleared safely when events are deleted.
  * Event deletion is restricted to event owners; room coordinators can no longer delete events.
  * Audit history remains available after related authorization records are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->