### PR TITLE
Issue #475: ChunkAggregator handle_chunk failing on forced finalization logic with 15 seconds and 50 words rule

### DIFF
--- a/portal/transcription/aggregator.py
+++ b/portal/transcription/aggregator.py
@@ -86,21 +86,14 @@ class CaptionAggregator:
                     has_finalized = True
 
                 state.current_utterance = remainder
+                if state.current_utterance:
+                    state.utterance_start_time = time.time()
+                else:
+                    state.utterance_start_time = 0.0
 
         state.current_word_count = len(state.current_utterance.split()) if state.current_utterance else 0
-        if state.current_utterance:
-            state.utterance_start_time = time.time()
-        else:
-            state.utterance_start_time = 0.0
 
         if state.current_utterance:
-            await self.broadcast_callback(
-                booth_id, {"type": "caption", "status": "partial", "text": state.current_utterance}
-            )
-        elif has_finalized:
-            # Only send clear if we just finalized something and have nothing left,
-            # ensuring the frontend's partial box is cleared out.
-            await self.broadcast_callback(booth_id, {"type": "caption", "status": "clear", "text": ""})
             if state.current_word_count >= 50 or (time.time() - state.utterance_start_time) >= 15.0:
                 logger.info(f"[{booth_id}] Forced chunk finalization triggered (words: {state.current_word_count})")
                 await self.handle_final(booth_id, state.current_utterance)
@@ -109,6 +102,10 @@ class CaptionAggregator:
             await self.broadcast_callback(
                 booth_id, {"type": "caption", "status": "partial", "text": state.current_utterance}
             )
+        elif has_finalized:
+            # Only send clear if we just finalized something and have nothing left,
+            # ensuring the frontend's partial box is cleared out.
+            await self.broadcast_callback(booth_id, {"type": "caption", "status": "clear", "text": ""})
 
     async def handle_final(self, booth_id: str, text: str):
         state = self._get_state(booth_id)

--- a/portal/transcription/aggregator.py
+++ b/portal/transcription/aggregator.py
@@ -108,6 +108,10 @@ class CaptionAggregator:
             await self.broadcast_callback(booth_id, {"type": "caption", "status": "clear", "text": ""})
 
     async def handle_final(self, booth_id: str, text: str):
+        """
+        Finalizes an utterance, triggers database save, and initiates translation.
+        Called automatically on punctuation split, timeout, or explicit clear.
+        """
         state = self._get_state(booth_id)
         final_text = text.strip() or state.current_utterance
 

--- a/tests/test_aggregator_chunk.py
+++ b/tests/test_aggregator_chunk.py
@@ -1,0 +1,50 @@
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from portal.transcription.aggregator import CaptionAggregator
+
+
+@pytest.mark.anyio
+async def test_bug_50_word_limit_in_handle_chunk():
+    received = []
+
+    async def fake_callback(booth_id, message):
+        received.append(message)
+
+    aggregator = CaptionAggregator(fake_callback)
+
+    # 60 words with no punctuation
+    long_text = "word " * 60
+
+    await aggregator.handle_chunk("booth-1", long_text)
+
+    finals = [m for m in received if m.get("status") == "final"]
+
+    # This assertion will fail because handle_chunk never triggers forced finalization!
+    assert len(finals) > 0, "BUG: Passed 60 words, but no final caption was emitted!"
+
+
+@pytest.mark.anyio
+@patch("time.time")
+async def test_bug_15_second_limit_in_handle_chunk(mock_time):
+    received = []
+
+    async def fake_callback(booth_id, message):
+        received.append(message)
+
+    aggregator = CaptionAggregator(fake_callback)
+
+    # Start at time 0
+    mock_time.return_value = 0.0
+    await aggregator.handle_chunk("booth-1", "first chunk ")
+
+    # Jump 20 seconds into the future
+    mock_time.return_value = 20.0
+    await aggregator.handle_chunk("booth-1", "second chunk")
+
+    finals = [m for m in received if m.get("status") == "final"]
+
+    # This assertion will fail because the time limit is defeated!
+    assert len(finals) > 0, "BUG: 20 seconds passed, but no final caption was emitted!"

--- a/tests/test_aggregator_chunk.py
+++ b/tests/test_aggregator_chunk.py
@@ -8,9 +8,11 @@ from portal.transcription.aggregator import CaptionAggregator
 
 @pytest.mark.anyio
 async def test_forced_finalization_at_50_words_in_handle_chunk():
+    """Test that handle_chunk forcefully finalizes an utterance when it exceeds 50 words without punctuation."""
     received = []
 
     async def fake_callback(booth_id, message):
+        """Mock callback to collect broadcasted caption messages."""
         received.append(message)
 
     aggregator = CaptionAggregator(fake_callback)
@@ -29,9 +31,11 @@ async def test_forced_finalization_at_50_words_in_handle_chunk():
 @pytest.mark.anyio
 @patch("time.time")
 async def test_forced_finalization_at_15_seconds_in_handle_chunk(mock_time):
+    """Test that handle_chunk forcefully finalizes an utterance when 15 seconds have passed since the start."""
     received = []
 
     async def fake_callback(booth_id, message):
+        """Mock callback to collect broadcasted caption messages."""
         received.append(message)
 
     aggregator = CaptionAggregator(fake_callback)

--- a/tests/test_aggregator_chunk.py
+++ b/tests/test_aggregator_chunk.py
@@ -7,7 +7,7 @@ from portal.transcription.aggregator import CaptionAggregator
 
 
 @pytest.mark.anyio
-async def test_bug_50_word_limit_in_handle_chunk():
+async def test_forced_finalization_at_50_words_in_handle_chunk():
     received = []
 
     async def fake_callback(booth_id, message):
@@ -22,13 +22,13 @@ async def test_bug_50_word_limit_in_handle_chunk():
 
     finals = [m for m in received if m.get("status") == "final"]
 
-    # This assertion will fail because handle_chunk never triggers forced finalization!
-    assert len(finals) > 0, "BUG: Passed 60 words, but no final caption was emitted!"
+    # Verify that the chunk is forcefully finalized after exceeding 50 words without punctuation
+    assert len(finals) > 0, "Expected a final caption to be emitted due to word count limit"
 
 
 @pytest.mark.anyio
 @patch("time.time")
-async def test_bug_15_second_limit_in_handle_chunk(mock_time):
+async def test_forced_finalization_at_15_seconds_in_handle_chunk(mock_time):
     received = []
 
     async def fake_callback(booth_id, message):
@@ -46,5 +46,5 @@ async def test_bug_15_second_limit_in_handle_chunk(mock_time):
 
     finals = [m for m in received if m.get("status") == "final"]
 
-    # This assertion will fail because the time limit is defeated!
-    assert len(finals) > 0, "BUG: 20 seconds passed, but no final caption was emitted!"
+    # Verify that the chunk is forcefully finalized after 15 seconds have passed
+    assert len(finals) > 0, "Expected a final caption to be emitted due to time limit"


### PR DESCRIPTION
## Description

This PR fixes the issue where ChunkAggregator handle_chunk fails to force finalize sentences with the 15 seconds and 50 words rule.

## Related Issue

Closes #475 

## Changes Made

- in `portal/transcription/aggregator.py` the logic at line 91 where the time is reset to current time for every new chunk is moved inside the logic of when sentence and remainder are split so that the time is assigned only when the remainder is formed.
- in `portal/transcription/aggregator.py` the logic at line 104 where the forced finalization rules are implemented are moved outside the `elif has_finalized` block and moved into the `if state.current.utterance` block where it can actually be addressed.
- A new test file has been created in `tests` called `tests/test_aggregator_chunk.py` which tests the cases where the old `handle_chunk` logic was breaking apart

## Testing

Building new tests in `tests/test_aggregator_chunk.py` which initially failed but after the changes ended up passing

- [x] Tested locally
- [x] Existing tests pass
- [x] Added/updated tests (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] My changes do not introduce new warnings or errors

## Summary by Sourcery

Ensure chunk aggregation reliably finalizes long-running or oversized utterances while preserving partial-caption behavior.

Bug Fixes:
- Fix forced utterance finalization so the 50-word and 15-second thresholds are applied reliably during chunk handling.

Enhancements:
- Preserve utterance start times across chunks and document the utterance finalization behavior.

Tests:
- Add coverage for word-count and elapsed-time forced finalization scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed caption aggregation so captions are finalized when they exceed the word limit, preventing overly long captions.
  * Fixed caption aggregation so captions are finalized when they exceed the time limit, improving timely delivery of spoken content.
  * Improved punctuation-based caption splitting and partial-caption updates for more consistent live caption display.
  * Improved handling of caption clearing and finalization so users receive the appropriate caption state after each update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->