### PR TITLE
fix :  fixing 403 error on OAuth authorization for newly provisioned events on eventyay

### DIFF
--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -178,7 +178,7 @@ async def authorize_get(
                     )
                 )
                 membership = membership_result.scalars().first()
-                
+
                 if membership:
                     membership.role = "event_owner"
                 else:

--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -159,14 +159,34 @@ async def authorize_get(
             if not evt:
                 raise HTTPException(status_code=500, detail="Failed to create or fetch event.")
 
-    try:
-        async with db.begin_nested():
-            # Give the authorizing user ownership
-            membership = EventMembership(user_id=int(user["sub"]), event_id=evt.id, role="event_owner")
-            db.add(membership)
-            await db.flush()
-    except IntegrityError:
-        pass
+    # Check if the event already has an owner
+    owner_result = await db.execute(
+        select(EventMembership).where(
+            EventMembership.event_id == evt.id,
+            EventMembership.role.in_(["event_owner", "super_admin", "owner"])
+        )
+    )
+    has_owner = owner_result.scalars().first() is not None
+
+    if not has_owner:
+        try:
+            async with db.begin_nested():
+                # Update existing membership or create new one as event_owner
+                membership_result = await db.execute(
+                    select(EventMembership).where(
+                        EventMembership.user_id == int(user["sub"]), EventMembership.event_id == evt.id
+                    )
+                )
+                membership = membership_result.scalars().first()
+                
+                if membership:
+                    membership.role = "event_owner"
+                else:
+                    membership = EventMembership(user_id=int(user["sub"]), event_id=evt.id, role="event_owner")
+                    db.add(membership)
+                await db.flush()
+        except IntegrityError:
+            pass
     # 3. Calculate Scopes
     requested_scopes = scope.split(" ") if scope else []
     effective_scopes = await get_effective_scopes(db, user, evt.id, requested_scopes)

--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -159,15 +159,14 @@ async def authorize_get(
             if not evt:
                 raise HTTPException(status_code=500, detail="Failed to create or fetch event.")
 
-        try:
-            async with db.begin_nested():
-                # Give the authorizing user ownership
-                membership = EventMembership(user_id=int(user["sub"]), event_id=evt.id, role="event_owner")
-                db.add(membership)
-                await db.flush()
-        except IntegrityError:
-            pass
-
+    try:
+        async with db.begin_nested():
+            # Give the authorizing user ownership
+            membership = EventMembership(user_id=int(user["sub"]), event_id=evt.id, role="event_owner")
+            db.add(membership)
+            await db.flush()
+    except IntegrityError:
+        pass
     # 3. Calculate Scopes
     requested_scopes = scope.split(" ") if scope else []
     effective_scopes = await get_effective_scopes(db, user, evt.id, requested_scopes)

--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -168,25 +168,6 @@ async def authorize_get(
     )
     has_owner = owner_result.scalars().first() is not None
 
-    if not has_owner:
-        try:
-            async with db.begin_nested():
-                # Update existing membership or create new one as event_owner
-                membership_result = await db.execute(
-                    select(EventMembership).where(
-                        EventMembership.user_id == int(user["sub"]), EventMembership.event_id == evt.id
-                    )
-                )
-                membership = membership_result.scalars().first()
-
-                if membership:
-                    membership.role = "event_owner"
-                else:
-                    membership = EventMembership(user_id=int(user["sub"]), event_id=evt.id, role="event_owner")
-                    db.add(membership)
-                await db.flush()
-        except IntegrityError:
-            pass
     # 3. Calculate Scopes
     requested_scopes = scope.split(" ") if scope else []
     effective_scopes = await get_effective_scopes(db, user, evt.id, requested_scopes, assume_owner=not has_owner)

--- a/portal/routers/oauth.py
+++ b/portal/routers/oauth.py
@@ -66,7 +66,7 @@ def verify_pkce(code_verifier: str, code_challenge: str, method: str) -> bool:
     return False
 
 
-async def get_effective_scopes(db: AsyncSession, user: dict, event_id: int, requested_scopes: list[str]) -> list[str]:
+async def get_effective_scopes(db: AsyncSession, user: dict, event_id: int, requested_scopes: list[str], assume_owner: bool = False) -> list[str]:
     # Check if user has EventMembership
     result = await db.execute(
         select(EventMembership).where(EventMembership.user_id == int(user["sub"]), EventMembership.event_id == event_id)
@@ -77,7 +77,7 @@ async def get_effective_scopes(db: AsyncSession, user: dict, event_id: int, requ
     # simplified for now: if they have any role in the event, we grant scopes they requested
     # that map to their role.
     # Accept "owner" as a synonym for "event_owner" (e.g. roles synced from Eventyay)
-    is_event_admin = event_membership and event_membership.role in ("event_owner", "super_admin", "owner")
+    is_event_admin = assume_owner or (event_membership and event_membership.role in ("event_owner", "super_admin", "owner"))
     is_room_coordinator = event_membership and event_membership.role == "room_coordinator"
 
     # In a full implementation, we would narrow this down per-room.
@@ -189,7 +189,7 @@ async def authorize_get(
             pass
     # 3. Calculate Scopes
     requested_scopes = scope.split(" ") if scope else []
-    effective_scopes = await get_effective_scopes(db, user, evt.id, requested_scopes)
+    effective_scopes = await get_effective_scopes(db, user, evt.id, requested_scopes, assume_owner=not has_owner)
 
     if not effective_scopes:
         raise HTTPException(
@@ -247,6 +247,41 @@ async def authorize_post(
         error_query = urllib.parse.urlencode(existing_query)
         error_url = urllib.parse.urlunparse(parsed_redirect._replace(query=error_query))
         return RedirectResponse(url=error_url, status_code=303)
+
+    # Ensure event exists and lock it for ownership assignment
+    locked_event_result = await db.execute(
+        select(Event).with_for_update().where(Event.id == event_id)
+    )
+    locked_event = locked_event_result.scalars().first()
+    if not locked_event:
+        raise HTTPException(status_code=404, detail="Event not found.")
+
+    owner_result = await db.execute(
+        select(EventMembership).where(
+            EventMembership.event_id == event_id,
+            EventMembership.role.in_(["event_owner", "super_admin", "owner"])
+        )
+    )
+    has_owner = owner_result.scalars().first() is not None
+
+    if not has_owner:
+        from sqlalchemy.exc import IntegrityError
+        try:
+            async with db.begin_nested():
+                membership_result = await db.execute(
+                    select(EventMembership).where(
+                        EventMembership.user_id == int(user["sub"]), EventMembership.event_id == event_id
+                    )
+                )
+                membership = membership_result.scalars().first()
+                if membership:
+                    membership.role = "event_owner"
+                else:
+                    membership = EventMembership(user_id=int(user["sub"]), event_id=event_id, role="event_owner")
+                    db.add(membership)
+                await db.flush()
+        except IntegrityError:
+            pass
 
     # Re-validate scopes live
     effective_scopes = await get_effective_scopes(db, user, event_id, scope.split(" "))


### PR DESCRIPTION
- **Description:** Fixes a bug where connecting a newly created Eventyay event to VoxBento throws a 403 Access Denied error.

- **Root Cause & Fix:** If an event was pre-provisioned via an API webhook, the OAuth flow found the event and accidentally skipped the block of code that grants the authorizing user event_owner membership. Without this role, the user couldn't grant the requested scopes.

This PR moves the EventMembership creation block outside of the if not evt: condition, ensuring the authorizing user is always granted ownership during the OAuth handshake.

## Summary by Sourcery

Fix OAuth authorization for newly provisioned events by ensuring the authorizing user has the ownership required to grant requested scopes.

Bug Fixes:
- Ensure OAuth authorization grants or restores event ownership for users connecting pre-provisioned events, preventing 403 Access Denied errors.

Enhancements:
- Improve OAuth scope evaluation and ownership assignment by recognizing existing owner roles and safely handling concurrent ownership initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth event setup by preserving existing event ownership.
  * When an event has no owner, ownership is assigned to the authorizing user through an existing membership or a newly created membership.
  * Prevented concurrent authorization requests from assigning conflicting ownership.
  * Missing events now return a not-found response during authorization.
  * Authorizing users receive appropriate event administration access when no owner is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->